### PR TITLE
Update JWT Version

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httpauth', '~> 0.1'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'rack', '~> 1.2'
-  gem.add_dependency 'jwt', '~> 0.1.4'
+  gem.add_dependency 'jwt', '1.5.6'
   gem.add_development_dependency 'addressable'
   gem.add_development_dependency 'multi_xml'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
We need a higher JWT Version in the Backupify app and this is blocking it. I don't see any breaking changes in the changelog https://github.com/jwt/ruby-jwt/blob/master/CHANGELOG.md. The only thing that backupify depends on this gem for is Salesforce and I have verified that it still works.